### PR TITLE
hello

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,8 +25,12 @@
     },
     "agenix": {
       "inputs": {
-        "darwin": "darwin",
-        "home-manager": "home-manager",
+        "darwin": [
+          "darwin"
+        ],
+        "home-manager": [
+          "home-manager"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -47,37 +51,15 @@
     "darwin": {
       "inputs": {
         "nixpkgs": [
-          "agenix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1673295039,
-        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
-        "owner": "lnl7",
-        "repo": "nix-darwin",
-        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
-        "type": "github"
-      },
-      "original": {
-        "owner": "lnl7",
-        "ref": "master",
-        "repo": "nix-darwin",
-        "type": "github"
-      }
-    },
-    "darwin_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1766524813,
-        "narHash": "sha256-N/sxS27+t9nGvGWqwwAceSMW/Y5ddcypS/aiTnZ7ScA=",
+        "lastModified": 1767718503,
+        "narHash": "sha256-V+VkFs0aSG0ca8p/N3gib7FAf4cq9jyr5Gm+ZBrHQpo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "c2b36207f2c396c79dbed9d40536db221bd4e363",
+        "rev": "9f48ffaca1f44b3e590976b4da8666a9e86e6eb1",
         "type": "github"
       },
       "original": {
@@ -92,7 +74,9 @@
         "determinate-nixd-aarch64-linux": "determinate-nixd-aarch64-linux",
         "determinate-nixd-x86_64-linux": "determinate-nixd-x86_64-linux",
         "nix": "nix",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1766549083,
@@ -229,22 +213,6 @@
         "type": "github"
       }
     },
-    "flake-compat_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -366,8 +334,12 @@
       "inputs": {
         "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils",
-        "home-manager": "home-manager_2",
-        "nixpkgs": "nixpkgs_3",
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "zig": "zig",
         "zon2nix": "zon2nix"
       },
@@ -414,63 +386,20 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
-          "agenix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1682203081,
-        "narHash": "sha256-kRL4ejWDhi0zph/FpebFYhzqlOBrk0Pl3dzGEKSAlEw=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "32d3e39c491e2f91152c84f8ad8b003420eab0a1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager_2": {
-      "inputs": {
-        "nixpkgs": [
-          "ghostty",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1755776884,
-        "narHash": "sha256-CPM7zm6csUx7vSfKvzMDIjepEJv1u/usmaT7zydzbuI=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "4fb695d10890e9fc6a19deadf85ff79ffb78da86",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "release-25.05",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager_3": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1766682973,
-        "narHash": "sha256-GKO35onS711ThCxwWcfuvbIBKXwriahGqs+WZuJ3v9E=",
-        "rev": "91cdb0e2d574c64fae80d221f4bf09d5592e9ec2",
-        "revCount": 5935,
+        "lastModified": 1767909183,
+        "narHash": "sha256-u/bcU0xePi5bgNoRsiqSIwaGBwDilKKFTz3g0hqOBAo=",
+        "rev": "cd6e96d56ed4b2a779ac73a1227e0bb1519b3509",
+        "revCount": 6059,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.5935%2Brev-91cdb0e2d574c64fae80d221f4bf09d5592e9ec2/019b5684-118a-76b3-a8a8-41c252ffea2c/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.6059%2Brev-cd6e96d56ed4b2a779ac73a1227e0bb1519b3509/019b9f9a-6ba6-7eb9-b623-ae282f91dd4a/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/nix-community/home-manager/0.1.%2A.tar.gz"
+        "url": "https://flakehub.com/f/nix-community/home-manager/0.1"
       }
     },
     "nix": {
@@ -501,7 +430,9 @@
           "nix-gaming"
         ],
         "nix-github-actions": "nix-github-actions",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "systems": "systems_3",
         "treefmt-nix": "treefmt-nix"
       },
@@ -522,7 +453,9 @@
     "nix-gaming": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1766541727,
@@ -576,7 +509,9 @@
     "nixos-wsl": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1765841014,
@@ -641,7 +576,9 @@
     "nixpkgs-python": {
       "inputs": {
         "flake-compat": "flake-compat_4",
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1765052656,
@@ -649,25 +586,6 @@
         "owner": "cachix",
         "repo": "nixpkgs-python",
         "rev": "04b27dbad2e004cb237db202f21154eea3c4f89f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "nixpkgs-python",
-        "type": "github"
-      }
-    },
-    "nixpkgs-python_2": {
-      "inputs": {
-        "flake-compat": "flake-compat_5",
-        "nixpkgs": "nixpkgs_10"
-      },
-      "locked": {
-        "lastModified": 1733319315,
-        "narHash": "sha256-cFQBdRmtIZFVjr2P6NkaCOp7dddF93BC0CXBwFZFaN0=",
-        "owner": "cachix",
-        "repo": "nixpkgs-python",
-        "rev": "01263eeb28c09f143d59cd6b0b7c4cc8478efd48",
         "type": "github"
       },
       "original": {
@@ -692,157 +610,18 @@
         "type": "github"
       }
     },
-    "nixpkgs_10": {
-      "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
-        "lastModified": 1755186698,
-        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1766314097,
-        "narHash": "sha256-laJftWbghBehazn/zxVJ8NdENVgjccsWAdAqKXhErrM=",
-        "rev": "306ea70f9eb0fb4e040f8540e2deab32ed7e2055",
-        "revCount": 914780,
+        "lastModified": 1767767207,
+        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "revCount": 923638,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.914780%2Brev-306ea70f9eb0fb4e040f8540e2deab32ed7e2055/019b49b8-ed0f-724e-bdaf-5fd90cc1c590/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1763191728,
-        "narHash": "sha256-gI9PpaoX4/f28HkjcTbFVpFhtOxSDtOEdFaHZrdETe0=",
-        "rev": "1d4c88323ac36805d09657d13a5273aea1b34f0c",
-        "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre896415.1d4c88323ac3/nixexprs.tar.xz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.923638%2Brev-5912c1772a44e31bf1c63c0390b90501e5026886/019b99bc-df15-7804-bd2c-852778ee75cb/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1766309749,
-        "narHash": "sha256-3xY8CZ4rSnQ0NqGhMKAy5vgC+2IVK0NoVEzDoOh4DA4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a6531044f6d0bef691ea18d4d4ce44d0daa6e816",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1766125104,
-        "narHash": "sha256-l/YGrEpLromL4viUo5GmFH3K5M1j0Mb9O+LiaeCPWEM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7d853e518814cca2a657b72eeba67ae20ebf7059",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1765472234,
-        "narHash": "sha256-9VvC20PJPsleGMewwcWYKGzDIyjckEz8uWmT0vCDYK0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "2fbfb1d73d239d2402a8fe03963e37aab15abe8b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1766651565,
-        "narHash": "sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU=",
-        "rev": "3e2499d5539c16d0d173ba53552a4ff8547f4539",
-        "revCount": 916364,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.916364%2Brev-3e2499d5539c16d0d173ba53552a4ff8547f4539/019b55f3-ffa1-7567-85ec-0561fc22d452/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
-      }
-    },
-    "nixpkgs_8": {
-      "locked": {
-        "lastModified": 1753345091,
-        "narHash": "sha256-CdX2Rtvp5I8HGu9swBmYuq+ILwRxpXdJwlpg8jvN4tU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3ff0e34b1383648053bba8ed03f201d3466f90c9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1736549401,
-        "narHash": "sha256-ibkQrMHxF/7TqAYcQE+tOnIsSEzXmMegzyBWza6uHKM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1dab772dd4a68a7bba5d9460685547ff8e17d899",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.914755"
       }
     },
     "nvim-treesitter": {
@@ -882,8 +661,12 @@
     "pyenv-nix-install": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_9",
-        "nixpkgs-python": "nixpkgs-python_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-python": [
+          "nixpkgs-python"
+        ]
       },
       "locked": {
         "lastModified": 1736687409,
@@ -903,15 +686,15 @@
       "inputs": {
         "LazyVim": "LazyVim",
         "agenix": "agenix",
-        "darwin": "darwin_2",
+        "darwin": "darwin",
         "determinate": "determinate",
         "ghostty": "ghostty",
-        "home-manager": "home-manager_3",
+        "home-manager": "home-manager",
         "nix-citizen": "nix-citizen",
         "nix-gaming": "nix-gaming",
         "nixos-hardware": "nixos-hardware",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-python": "nixpkgs-python",
         "pyenv-nix-install": "pyenv-nix-install",
         "starship-jj": "starship-jj",
@@ -939,7 +722,9 @@
       "inputs": {
         "fenix": "fenix",
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_11",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "systems": "systems_5"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,23 +1,32 @@
 {
   description = "User Config";
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
-    nixos-wsl.url = "github:nix-community/NixOS-WSL/main";
-    determinate.url = "https://flakehub.com/f/DeterminateSystems/determinate/*";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.914755";
+    nixos-wsl = {
+      url = "github:nix-community/NixOS-WSL/main";
+      inputs.nixpkgs.follows = "nixpkgs";
+
+    };
+    determinate = {
+      url = "https://flakehub.com/f/DeterminateSystems/determinate/*";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     home-manager = {
-      url = "https://flakehub.com/f/nix-community/home-manager/0.1.*.tar.gz";
+      url = "https://flakehub.com/f/nix-community/home-manager/0.1";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     darwin = {
-      url = "github:LnL7/nix-darwin";
+      url = "github:LnL7/nix-darwin/";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     agenix = {
       url = "https://flakehub.com/f/ryantm/agenix/0.14.*.tar.gz";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.darwin.follows = "darwin";
+      inputs.home-manager.follows = "home-manager";
     };
 
     nixos-hardware = {
@@ -31,14 +40,24 @@
 
     ghostty = {
       url = "github:ghostty-org/ghostty";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
     };
 
     starship-jj = {
       url = "gitlab:lanastara_foss/starship-jj";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    nixpkgs-python.url = "github:cachix/nixpkgs-python";
-    pyenv-nix-install.url = "github:sirno/pyenv-nix-install";
+    nixpkgs-python = {
+      url = "github:cachix/nixpkgs-python";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    pyenv-nix-install = {
+      url = "github:sirno/pyenv-nix-install";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs-python.follows = "nixpkgs-python";
+    };
 
     zen-browser = {
       url = "github:youwen5/zen-browser-flake";
@@ -46,9 +65,15 @@
     };
 
     # gaming
-    nix-citizen.url = "github:LovingMelody/nix-citizen";
-    nix-gaming.url = "github:fufexan/nix-gaming";
-    nix-citizen.inputs.nix-gaming.follows = "nix-gaming";
+    nix-citizen = {
+      url = "github:LovingMelody/nix-citizen";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nix-gaming.follows = "nix-gaming";
+    };
+    nix-gaming = {
+      url = "github:fufexan/nix-gaming";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/home/modules/lazy/plugins/treesitter-context.lua
+++ b/home/modules/lazy/plugins/treesitter-context.lua
@@ -1,3 +1,0 @@
-return {
-	{ "nvim-treesitter/nvim-treesitter-context", opts = { max_lines = 4 } },
-}

--- a/home/modules/lazyvim.nix
+++ b/home/modules/lazyvim.nix
@@ -107,7 +107,6 @@ in
             oil-nvim
             rustaceanvim
             nvim-spider
-            nvim-treesitter-context
             mini-surround
             (fromGitHub "ibhagwan" "smartyank.nvim" "2024nov10" "0a4554a4ea4cad73dab0a15e559f2128ca03c7b2")
             undotree
@@ -162,7 +161,6 @@ in
             "smartyank.lua".source = ./lazy/plugins/smartyank.lua;
             "snacks.lua".source = ./lazy/plugins/snacks.lua;
             "spider.lua".source = ./lazy/plugins/spider.lua;
-            "treesitter-context.lua".source = ./lazy/plugins/treesitter-context.lua;
             "extras.lua".text = concatStringsSep "\n"
               (filter (s: s != "") [
                 "return {"


### PR DESCRIPTION
### Summary

This pull request introduces a significant refactoring of the Nix flake's input management by consistently using the `follows` mechanism. This change ensures that all flake inputs use a single, consistent version of shared dependencies, primarily `nixpkgs`. Concurrently, all flake inputs have been updated to their latest versions.

As a minor cleanup, the `nvim-treesitter-context` plugin has been removed from the Neovim configuration.

### Files Changed

*   **`flake.nix`**: Modified to enforce dependency consistency. All inputs that depend on `nixpkgs` (and other shared inputs) now explicitly follow the root `nixpkgs` input.
*   **`flake.lock`**: Updated to reflect the new dependency graph and the updated versions of all inputs. This file shows a significant reduction in duplicate dependencies (e.g., `nixpkgs_2`, `nixpkgs_3`, etc. are now consolidated).
*   **`home/modules/lazyvim.nix`**: Modified to remove the `nvim-treesitter-context` plugin from the Neovim configuration.
*   **`home/modules/lazy/plugins/treesitter-context.lua`**: Deleted, as it contained the configuration for the removed plugin.

### Code Changes

#### Flake Input Refactoring

The primary change is the adoption of the `follows` pattern for managing flake inputs. This ensures that a single version of a dependency is used across the entire evaluation, preventing inconsistencies and reducing the final closure size.

**Before:**
```nix
{
  inputs = {
    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
    nixos-wsl.url = "github:nix-community/NixOS-WSL/main";
    // ... other inputs pulling their own nixpkgs
  };
}
```

**After:**
```nix
{
  inputs = {
    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.914755";
    nixos-wsl = {
      url = "github:nix-community/NixOS-WSL/main";
      inputs.nixpkgs.follows = "nixpkgs";
    };
    // ... all other inputs now follow the root nixpkgs
  };
}
```
This pattern was applied to all relevant inputs, such as `home-manager`, `darwin`, `agenix`, and others.

#### Neovim Plugin Removal

The `nvim-treesitter-context` plugin and its configuration were removed.

**In `home/modules/lazyvim.nix`:**
```diff
-            nvim-treesitter-context
```

**In `home/modules/lazyvim.nix`:**
```diff
-            "treesitter-context.lua".source = ./lazy/plugins/treesitter-context.lua;
```

### Reason for Changes

1.  **Dependency Consistency**: The previous flake structure allowed transitive dependencies to pull in their own, often different, versions of `nixpkgs`. This could lead to a bloated Nix store, longer build times, and subtle inconsistencies. Using `follows` is a Nix flakes best practice that creates a more robust, predictable, and efficient build process.
2.  **Dependency Updates**: As part of the refactoring, `nix flake update` was run to bring all dependencies to their latest compatible versions, incorporating upstream bug fixes and features.
3.  **Configuration Cleanup**: The `nvim-treesitter-context` plugin's functionality, which displays the code context at the top of the editor, is often redundant with modern LSP features or other UI elements. Its removal simplifies the Neovim configuration with minimal impact on functionality.

### Impact of Changes

*   **Improved Maintainability**: The dependency graph is now simpler and more explicit, making future updates easier to manage.
*   **Build Efficiency**: System closures should be smaller due to the deduplication of `nixpkgs` and other shared dependencies.
*   **System-wide Update**: All packages and modules from external flakes have been updated. This will require a full system rebuild upon switching to this branch.
*   **Potential for Regressions**: A large-scale dependency update always carries the risk of introducing breaking changes from upstream projects. While the build was successful on my target systems, subtle runtime issues could exist.

### Test Plan

1.  Ran `nix flake check --all-systems` to ensure the flake evaluates correctly across all supported architectures.
2.  Successfully executed `nixos-rebuild switch --flake .#<hostname>` on my primary NixOS machine.
3.  Successfully executed `darwin-rebuild switch --flake .#<hostname>` on my Darwin machine.
4.  Launched Neovim and confirmed it starts without errors and that the treesitter context UI is no longer present.

Reviewers are encouraged to build their own configurations using this flake to ensure compatibility.

### Additional Notes

A full system rebuild will be triggered after pulling these changes. This is expected and necessary to apply the updated dependencies.
